### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate release
+        run: |
+          git archive --format=zip --prefix=miku-cursor-linux/ HEAD:miku-cursor-linux/ -o miku-cursor-linux.zip
+          git archive --format=zip --prefix=miku-cursor-windows/ HEAD:miku-cursor-windows/ -o miku-cursor-windows.zip
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            miku-cursor-linux.zip
+            miku-cursor-windows.zip


### PR DESCRIPTION
Sorry for taking so long getting to this! I've been working on some other things. If the assets are uploaded in the github workflow, then they will be downloadable with the source code, which is how I imagined that releases could work.

For a demo of how this works, take a look at my fork: https://github.com/4e554c4c/hatsune-miku-windows-linux-cursors/releases/tag/v0.0.1

Fixes #4 